### PR TITLE
fix: show all active random-event participants

### DIFF
--- a/src/dice/random-events/infrastructure/live-runtime-presentation.ts
+++ b/src/dice/random-events/infrastructure/live-runtime-presentation.ts
@@ -73,8 +73,15 @@ export const buildActiveClaimDescription = (
   prompt: string,
   activityLine: string | null,
   expiresAtMs: number | null,
+  participants: string[] = [],
 ): string => {
   const lines = [prompt];
+
+  if (participants.length > 0) {
+    const participantMentions = participants.map((userId) => `<@${userId}>`).join(", ");
+    const participantLabel = participants.length === 1 ? "Participant" : "Participants";
+    lines.push("", `**${participantLabel} so far:** ${participantMentions}`);
+  }
 
   if (activityLine) {
     lines.push("", activityLine);

--- a/src/dice/random-events/infrastructure/live-runtime.ts
+++ b/src/dice/random-events/infrastructure/live-runtime.ts
@@ -94,6 +94,7 @@ export const createRandomEventsLiveRuntime = ({
         context.selection.renderedPrompt,
         activityLine,
         windowSnapshot?.expiresAtMs ?? null,
+        windowSnapshot?.participants ?? [],
       ),
       buttonCustomId: buildRandomEventClaimButtonId(eventId),
       buttonLabel: context.selection.renderedClaimLabel,


### PR DESCRIPTION
# Summary
show the full participant list while a multi-user random event is still gathering players
keep the existing activity line, but stop overwriting the visible attendee history with only the latest joiner

# Validation
npm run typecheck
npm run build


Closes https://github.com/tero-laanti/rolly-bot/issues/12