### PR TITLE
random-events: cap visible participant list in active prompts

### DIFF
--- a/src/dice/random-events/infrastructure/live-runtime-presentation.ts
+++ b/src/dice/random-events/infrastructure/live-runtime-presentation.ts
@@ -69,12 +69,30 @@ export const buildClaimActivityLine = (
   return `<@${userId}> did ${actionText}.`;
 };
 
+const formatParticipantMentions = (participants: string[], maxVisible = 5): string => {
+  const visibleParticipants = participants.slice(0, maxVisible).map((userId) => `<@${userId}>`);
+  const hiddenCount = participants.length - visibleParticipants.length;
+
+  if (hiddenCount < 1) {
+    return visibleParticipants.join(", ");
+  }
+
+  const hiddenLabel = `and ${hiddenCount} more`;
+  return `${visibleParticipants.join(", ")}, ${hiddenLabel}`;
+};
+
 export const buildActiveClaimDescription = (
   prompt: string,
   activityLine: string | null,
   expiresAtMs: number | null,
+  participants: string[] = [],
 ): string => {
   const lines = [prompt];
+
+  if (participants.length > 0) {
+    const participantLabel = participants.length === 1 ? "Participant" : "Participants";
+    lines.push("", `**${participantLabel} so far:** ${formatParticipantMentions(participants)}`);
+  }
 
   if (activityLine) {
     lines.push("", activityLine);

--- a/src/dice/random-events/infrastructure/live-runtime.ts
+++ b/src/dice/random-events/infrastructure/live-runtime.ts
@@ -94,6 +94,7 @@ export const createRandomEventsLiveRuntime = ({
         context.selection.renderedPrompt,
         activityLine,
         windowSnapshot?.expiresAtMs ?? null,
+        windowSnapshot?.participants ?? [],
       ),
       buttonCustomId: buildRandomEventClaimButtonId(eventId),
       buttonLabel: context.selection.renderedClaimLabel,


### PR DESCRIPTION
# Summary
show the full participant list while a multi-user random event is still gathering players
keep the existing activity line, but stop overwriting the visible attendee history with only the latest joiner

# Validation
npm run typecheck
npm run build


Closes https://github.com/tero-laanti/rolly-bot/issues/12